### PR TITLE
Resolve NPE when sorting steps by dates with null values

### DIFF
--- a/plugin/src/de/intranda/digiverso/model/helper/DashboardHelperTasks.java
+++ b/plugin/src/de/intranda/digiverso/model/helper/DashboardHelperTasks.java
@@ -166,7 +166,7 @@ public class DashboardHelperTasks {
                     TaskChangeType tct = new TaskChangeType(currentStep, followingStep, process);
                     taskChangeHistory.add(tct);
                 }
-                taskChangeHistory.sort(Comparator.comparing(tct -> tct.getClosedStep().getBearbeitungsende()));
+    //            taskChangeHistory.sort(Comparator.comparing(tct -> tct.getClosedStep().getBearbeitungsende()));
             }
         }
 

--- a/plugin/src/de/intranda/digiverso/model/helper/DashboardHelperTasks.java
+++ b/plugin/src/de/intranda/digiverso/model/helper/DashboardHelperTasks.java
@@ -1,45 +1,5 @@
 package de.intranda.digiverso.model.helper;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-/**
- * This file is part of a plugin for the Goobi Application - a Workflow tool for the support of mass digitization.
- * 
- * Visit the websites for more information.
- *          - https://goobi.io
- *          - https://www.intranda.com
- *          - https://github.com/intranda/goobi
- * 
- * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59
- * Temple Place, Suite 330, Boston, MA 02111-1307 USA
- * 
- * Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions
- * of the GNU General Public License cover the whole combination. As a special exception, the copyright holders of this library give you permission to
- * link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and
- * conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this
- * library, you may extend this exception to your version of the library, but you are not obliged to do so. If you do not wish to do so, delete this
- * exception statement from your version.
- */
-import java.util.List;
-
-import org.apache.commons.configuration.XMLConfiguration;
-import org.goobi.beans.Process;
-import org.goobi.beans.Step;
-import org.goobi.beans.User;
-import org.goobi.managedbeans.ProcessBean;
-import org.goobi.managedbeans.StepBean;
-import org.goobi.production.flow.statistics.hibernate.FilterHelper;
-
 import de.intranda.digiverso.model.tasks.TaskChangeType;
 import de.intranda.digiverso.model.tasks.TaskHistory;
 import de.sub.goobi.helper.Helper;
@@ -50,6 +10,48 @@ import de.sub.goobi.persistence.managers.ProcessManager;
 import de.sub.goobi.persistence.managers.StepManager;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.goobi.beans.Process;
+import org.goobi.beans.Step;
+import org.goobi.beans.User;
+import org.goobi.managedbeans.ProcessBean;
+import org.goobi.managedbeans.StepBean;
+import org.goobi.production.flow.statistics.hibernate.FilterHelper;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+
+
+/**
+ * This file is part of a plugin for the Goobi Application - a Workflow tool for the support of mass digitization.
+ * <p>
+ * Visit the websites for more information.
+ * - https://goobi.io
+ * - https://www.intranda.com
+ * - https://github.com/intranda/goobi
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * <p>
+ * Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions
+ * of the GNU General Public License cover the whole combination. As a special exception, the copyright holders of this library give you permission to
+ * link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and
+ * conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the library, but you are not obliged to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
 
 public class DashboardHelperTasks {
 
@@ -163,10 +165,18 @@ public class DashboardHelperTasks {
                             break;
                         }
                     }
-                    TaskChangeType tct = new TaskChangeType(currentStep, followingStep, process);
-                    taskChangeHistory.add(tct);
+                    if (currentStep != null) {
+                        TaskChangeType tct = new TaskChangeType(currentStep, followingStep, process);
+                        taskChangeHistory.add(tct);
+                    }
                 }
-    //            taskChangeHistory.sort(Comparator.comparing(tct -> tct.getClosedStep().getBearbeitungsende()));
+                if (taskChangeHistory.size() > 1) {
+                    // Ensure null-safe comparison for the date
+                    taskChangeHistory.sort(Comparator.comparing(
+                            taskChangeType -> taskChangeType.getClosedStep().getBearbeitungsende(),
+                            Comparator.nullsLast(Comparator.reverseOrder()))
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
This Pull Request solves an error where NullPointerException is thrown when trying to sort closed steps by dates with null values. We noticed it occurs when you have a fresh installed Goobi instance (see attached image). Credits to our colleague, Øyvind Liland Gjesdal for debugging and finding out the cause.

<img width="1439" alt="process_dashboard_plugin_npe" src="https://user-images.githubusercontent.com/6852897/121790303-5427ba00-cbde-11eb-9f93-b3d376b61812.png">


Below is the details of the error from Goobi logs (truncated for easy readability). 
```
2021-06-11 17:50:27 ERROR GoobiExceptionHandler:82 - CLASS: javax.faces.FacesException
2021-06-11 17:50:27 ERROR GoobiExceptionHandler:99 - /file:/opt/digiverso/goobi/plugins/GUI/plugin_intranda_dashboard_extended-GUI.jar!/META-INF/resources/uii/plugin_dashboard_include_assignedSteps.xhtml @16,143 rendered="#{DashboardForm.plugin.tasksHelper.showTasks and DashboardForm.plugin.tasksHelper.assignedSteps.size() gt 0}": Error reading [tasksHelper] on type [de.intranda.goobi.plugins.ExtendedDashboard]
javax.faces.FacesException: /file:/opt/digiverso/goobi/plugins/GUI/plugin_intranda_dashboard_extended-GUI.jar!/META-INF/resources/uii/plugin_dashboard_include_assignedSteps.xhtml @16,143 rendered="#{DashboardForm.plugin.tasksHelper.showTasks and DashboardForm.plugin.tasksHelper.assignedSteps.size() gt 0}": Error reading [tasksHelper] on type [de.intranda.goobi.plugins.ExtendedDashboard]
        at com.sun.faces.lifecycle.ApplyRequestValuesPhase.execute(ApplyRequestValuesPhase.java:87) ~[javax.faces-
   ....
Caused by: javax.el.ELException: /file:/opt/digiverso/goobi/plugins/GUI/plugin_intranda_dashboard_extended-GUI.jar!/META-INF/resources/uii/plugin_dashboard_include_assignedSteps.xhtml @16,143 rendered="#{DashboardForm.plugin.tasksHelper.showTasks and DashboardForm.plugin.tasksHelper.assignedSteps.size() gt 0}": Error reading [tasksHelper] on type [de.intranda.goobi.plugins.ExtendedDashboard]
        at com.sun.faces.facelets.el.TagValueExpression.getValue(TagValueExpression.java:119) ~[javax.faces-2.3.9.jar:2.3.9]
        at javax.faces.component.ComponentStateHelper.eval(ComponentStateHelper.java:200) ~[javax.faces-2.3.9.jar:2.3.9]
        at javax.faces.component.UIComponentBase.isRendered(UIComponentBase.java:470) ~[javax.faces-2.3.9.jar:2.3.9]
        ... 33 more
Caused by: javax.el.ELException: Error reading [tasksHelper] on type [de.intranda.goobi.plugins.ExtendedDashboard]
        at javax.el.BeanELResolver.getValue(BeanELResolver.java:98) ~[tomcat9-el-api.jar:3.0.FR]
        at com.sun.faces.el.DemuxCompositeELResolver._getValue(DemuxCompositeELResolver.java:180) ~[javax.faces-2.3.9.jar:2.3.9]
        at com.sun.faces.el.DemuxCompositeELResolver.getValue(DemuxCompositeELResolver.java:208) ~[javax.faces-
        ... 33 more
Caused by: java.lang.NullPointerException
        at java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:469) ~[?:?]
        at java.util.TimSort.countRunAndMakeAscending(TimSort.java:355) ~[?:?]
        at java.util.TimSort.sort(TimSort.java:220) ~[?:?]
        at java.util.Arrays.sort(Arrays.java:1515) ~[?:?]
        at java.util.ArrayList.sort(ArrayList.java:1750) ~[?:?]
        at de.intranda.digiverso.model.helper.DashboardHelperTasks.<init>(DashboardHelperTasks.java:169) ~[?:?]
        ... 33 more
```
